### PR TITLE
デプロイエラー修正(condition_id)

### DIFF
--- a/db/migrate/20201021101142_create_products.rb
+++ b/db/migrate/20201021101142_create_products.rb
@@ -12,10 +12,6 @@ class CreateProducts < ActiveRecord::Migration[6.0]
       t.integer :condition_id, null: false
       t.integer :delivery_charge_id, null: false
       t.integer :shipping_day_id, null: false
-      t.string :condition_id, null: false
-      t.string :delivery_charge_id, null: false
-      t.string :prefecture_id, null: false
-      t.string :shipping_day_id, null: false
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,10 +57,6 @@ ActiveRecord::Schema.define(version: 2020_11_04_122600) do
     t.integer "condition_id", null: false
     t.integer "delivery_charge_id", null: false
     t.integer "shipping_day_id", null: false
-    t.string "condition_id", null: false
-    t.string "delivery_charge_id", null: false
-    t.string "prefecture_id", null: false
-    t.string "shipping_day_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "category_id", null: false


### PR DESCRIPTION
# What
最終課題をデプロイ時のyou can't define an already defined column 'condition_id’を解消するための実装

# Why
デプロイできないと、本番環境で使えないため。
