### PR TITLE
商品出品機能、バリデーション警告表示の改修、修正

### DIFF
--- a/app/assets/javascripts/product.js
+++ b/app/assets/javascripts/product.js
@@ -30,7 +30,8 @@ $(document).on("change","#parent_category", function() {
   if (parentCategory != "") {
     $.ajax( {
       type: 'GET',
-      url: 'get_category_children',
+      // urlは絶対パスで表示させる（こうしないとrenderで返された時に、選択できなくなるため）
+      url: '/products/get_category_children',
       data: { parent_name: parentCategory },
       dataType: 'json'
     })
@@ -59,7 +60,8 @@ $(document).on('change', '#children_box', function() {
   //子カテゴリーが初期値でない場合
   if (childId != ""){
     $.ajax({
-      url: 'get_category_grandchildren',
+      // urlは絶対パスで表示させる（こうしないとrenderで返された時に、選択できなくなるため）
+      url: '/products/get_category_grandchildren',
       type: 'GET',
       data: { child_id: childId },
       datatype: 'json'

--- a/app/assets/javascripts/product.js
+++ b/app/assets/javascripts/product.js
@@ -7,7 +7,7 @@ function appendOption(category) {
 function appendChildrenBox(insertHTML) {
   let childSelectHtml = '';
   childSelectHtml = 
-    `<select class="item_input__body__category__children--select" id="children_category" required="true">
+    `<select class="item_input__body__category__children--select" id="children_category">
        <option value="" data-category="" >選択してください</option>
        ${insertHTML}</select>
      <i class = "fa fa-chevron-down"></i>`;
@@ -17,7 +17,7 @@ function appendChildrenBox(insertHTML) {
 function appendGrandchildrenBox(insertHTML) {
   let grandchildSelectHtml = '';
   grandchildSelectHtml = 
-    `<select class="item_input__body__category__grandchildren--select" id="grandchildren_category" name="product[category_id]" required="true">
+    `<select class="item_input__body__category__grandchildren--select" id="grandchildren_category" name="product[category_id]">
        <option value="" data-category="" >選択してください</option>
        ${insertHTML}</select>
      `;

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -21,7 +21,10 @@ class ProductsController < ApplicationController
       redirect_to root_path , notice: "商品を出品しました。"
     else
       flash[:alert] = @product.errors.full_messages.join(',')
-      redirect_to new_product_path
+      if @product.images.length == 0
+      end
+        @product.images.new
+      render :new
     end
   end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,6 +1,6 @@
 class Product < ApplicationRecord
   belongs_to :user
-  belongs_to :category
+  belongs_to :category,    optional: true
   
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,6 +14,8 @@
 
   %body
     .notifications
-      - flash.each do |key, value|
-        = content_tag(:div, value, class: key)
+      - if flash[:alert]
+      - else
+        - flash.each do |key, value|
+          = content_tag(:div, value, class: key)
     = yield

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -56,7 +56,7 @@
             -# 下記コード(= form.collection_select〜)はコネクトで教えてもらった簡単な方法のため、残しておく。
             -# = form.collection_select :category_id, Category.roots, :id, :category_name, {include_blank: "選択してください", selected: 1},  class: "parent_category_box", id: "parent_category"
             -# 親カテゴリーのみで登録されては困るため、「select :category_id」を「「select :category」とする。
-            = form.select :category, options_for_select( @category_parent_array.map{|c| [c[:category_name], c[:id]]}),{include_blank: "選択してください"},  class: "parent_category_box", id: "parent_category", required: true
+            = form.select :category, options_for_select( @category_parent_array.map{|c| [c[:category_name], c[:id]]}),{include_blank: "選択してください"},  class: "parent_category_box", id: "parent_category"
             = icon('fa', 'chevron-down')
             .pulldown.item_input__body__category__children#children_box
               -#親カテゴリー選択によって子カテゴリー表示
@@ -99,8 +99,7 @@
           ¥
           =form.number_field :price
         =form.button "出品する" ,type: 'button' ,onclick: 'submit();' , class: "Submit"
--# ,value:"送信"
--# ,onclick: 'submit();'
+
         -# 余裕があれば実装（手数料計算、下書き保存）
         -# .Products__form__fees 販売手数料(10%)
         -# .Products__form__profits 販売利益

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -7,11 +7,12 @@
   .Products
     .Products__form
       =form_with model: @product, local:true do |form|
-        .Products__form__notification
-          - if flash[:alert]
-            - flash.each do |message_type, message|
-              - message2 = message.gsub(",","<br>")
-              = message2.html_safe
+        -# 動作確認のため、下記フラッシュメッセージは残しておく
+        -# .Products__form__notification
+        -#   - if flash[:alert]
+        -#     - flash.each do |message_type, message|
+        -#       - message2 = message.gsub(",","<br>")
+        -#       = message2.html_safe
         .Products__form__images
           =form.label :"商品画像"
           %span 必須
@@ -54,7 +55,7 @@
           .item_input__body__category#category_box
           .pulldown#partent_box
             -# 親カテゴリーのみで登録されては困るため、「select :category_id」を「「select :category」とする。
-            = form.select :category_id, options_for_select( @category_parent_array.map{|c| [c[:category_name], c[:id]]}),{include_blank: "選択してください"},  class: "parent_category_box", id: "parent_category", required: true
+            = form.select :category, options_for_select( @category_parent_array.map{|c| [c[:category_name], c[:id]]}),{include_blank: "選択してください"},  class: "parent_category_box", id: "parent_category", required: true
             = icon('fa', 'chevron-down')
             .pulldown.item_input__body__category__children#children_box
               -#親カテゴリー選択によって子カテゴリー表示
@@ -69,22 +70,22 @@
         .Products__form__condition
           =form.label "商品の状態"
           %span 必須
-          = form.collection_select :condition_id, Condition.all, :id, :name, { prompt: "選択してください" }, class:"Products__form__conditionSelect", required: true
+          = form.collection_select :condition_id, Condition.all, :id, :name, { prompt: "選択してください" }, class:"Products__form__conditionSelect"
 
         .Products__form__deliveryCharge
           =form.label "送料の負担"
           %span 必須
-          = form.collection_select :delivery_charge_id, DeliveryCharge.all, :id, :name, { prompt: "選択してください" }, class:"Products__form__conditionSelect", required: true
+          = form.collection_select :delivery_charge_id, DeliveryCharge.all, :id, :name, { prompt: "選択してください" }, class:"Products__form__conditionSelect"
 
         .Products__form__deliveryFrom
           =form.label "発送元地域"
           %span 必須
-          =form.collection_select :prefecture_id, Prefecture.all, :id, :name, { prompt: "選択してください" }, class: "Products__form__conditionSelect", required: true
+          =form.collection_select :prefecture_id, Prefecture.all, :id, :name, { prompt: "選択してください" }, class: "Products__form__conditionSelect"
 
         .Products__form__shippingDay
           =form.label "発送日数"
           %span 必須
-          =form.collection_select :shipping_day_id, ShippingDay.all, :id, :name, { prompt: "選択してください" }, class:"Products__form__shippingDaySelect", required: true
+          =form.collection_select :shipping_day_id, ShippingDay.all, :id, :name, { prompt: "選択してください" }, class:"Products__form__shippingDaySelect"
 
         .Products__form__price
           価格(300~9,999,999)
@@ -96,8 +97,9 @@
         .Products__form__yen
           ¥
           =form.number_field :price
-        =form.submit "出品する", class: "Submit"
-
+        =form.button "出品する" ,type: 'button' ,onclick: 'submit();' , class: "Submit"
+-# ,value:"送信"
+-# ,onclick: 'submit();'
         -# 余裕があれば実装（手数料計算、下書き保存）
         -# .Products__form__fees 販売手数料(10%)
         -# .Products__form__profits 販売利益

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -7,12 +7,11 @@
   .Products
     .Products__form
       =form_with model: @product, local:true do |form|
-        -# 動作確認のため、下記フラッシュメッセージは残しておく
-        -# .Products__form__notification
-        -#   - if flash[:alert]
-        -#     - flash.each do |message_type, message|
-        -#       - message2 = message.gsub(",","<br>")
-        -#       = message2.html_safe
+        .Products__form__notification
+          - if flash[:alert]
+            - flash.each do |message_type, message|
+              - message2 = message.gsub(",","<br>")
+              = message2.html_safe
         .Products__form__images
           =form.label :"商品画像"
           %span 必須
@@ -54,6 +53,8 @@
         .item_input__body
           .item_input__body__category#category_box
           .pulldown#partent_box
+            -# 下記コード(= form.collection_select〜)はコネクトで教えてもらった簡単な方法のため、残しておく。
+            -# = form.collection_select :category_id, Category.roots, :id, :category_name, {include_blank: "選択してください", selected: 1},  class: "parent_category_box", id: "parent_category"
             -# 親カテゴリーのみで登録されては困るため、「select :category_id」を「「select :category」とする。
             = form.select :category, options_for_select( @category_parent_array.map{|c| [c[:category_name], c[:id]]}),{include_blank: "選択してください"},  class: "parent_category_box", id: "parent_category", required: true
             = icon('fa', 'chevron-down')

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,6 +8,11 @@ ja:
         price: 商品価格
         infomation: 商品の説明
         images: 商品画像
+        prefecture_id: 発送元地域
+        condition_id: 商品の状態
+        delivery_charge_id: 送料の負担
+        shipping_day_id: 発送日数
+        category_id: カテゴリー
     errors:
       messages:
         record_invalid: 'バリデーションに失敗しました: %{errors}'

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -58,35 +58,35 @@ describe Product do
     it "is invalid without a prefecture_id" do
       product = build(:product, prefecture_id: nil)
       product.valid?
-      expect(product.errors.full_messages).to include("Prefectureを入力してください")
+      expect(product.errors.full_messages).to include("発送元地域を入力してください")
     end
 
     # 9. conditionが空では登録できないこと
     it "is invalid without a condition" do
       product = build(:product, condition_id: nil)
       product.valid?
-      expect(product.errors.full_messages).to include("Conditionを入力してください")
+      expect(product.errors.full_messages).to include("商品の状態を入力してください")
     end
 
     # 10. delivery_charge_idが空では登録できないこと
     it "is invalid without a delivery_charge_id" do
       product = build(:product, delivery_charge_id: nil)
       product.valid?
-      expect(product.errors.full_messages).to include("Delivery chargeを入力してください")
+      expect(product.errors.full_messages).to include("送料の負担を入力してください")
     end
 
-    # 11 . shipping_day_idが空では登録できないこと
+    # 11. shipping_day_idが空では登録できないこと
     it "is invalid without a shipping_day_id" do
       product = build(:product, shipping_day_id: nil)
       product.valid?
-      expect(product.errors.full_messages).to include("Shipping dayを入力してください")
+      expect(product.errors.full_messages).to include("発送日数を入力してください")
     end
 
     # 12. category_idが空では登録できないこと
     it "is invalid without a category_id" do
       product = build(:product, category_id: nil)
       product.valid?
-      expect(product.errors.full_messages).to include("Categoryを入力してください")
+      expect(product.errors.full_messages).to include("カテゴリーを入力してください")
     end
   end
 end


### PR DESCRIPTION
# What
商品出品機能に於いて、失敗時に値を保持する機能を付加する。また、Enterキーで誤送信するリスクが出たため、Enterキーでの送信を制限する。
これらに伴い、バリデーションの警告表示を修正する。

# Why
商品出品失敗時に値を保持できないと一から入力をする必要があり、不便であるため。
また、商品名等を入力時に文字変換などで誤ってEnterキーを連打し、送信されると不便であるため。
これらの改修に伴い、警告表示”required: true”が使えなくなったため、警告文の日本語化などを追加、修正する。
テストコードも一部変更したが、前回英語のままだったところを日本語に変更しただけで、バリデーション等に変更はない。