### PR TITLE
商品詳細ページにおける複数画像の表示及びコードレビュー指摘事項の修正

### DIFF
--- a/app/assets/javascripts/product.js
+++ b/app/assets/javascripts/product.js
@@ -9,8 +9,7 @@ function appendChildrenBox(insertHTML) {
   childSelectHtml = 
     `<select class="item_input__body__category__children--select" id="children_category">
        <option value="" data-category="" >選択してください</option>
-       ${insertHTML}</select>
-     <i class = "fa fa-chevron-down"></i>`;
+       ${insertHTML}</select>`;
   $('#children_box').append(childSelectHtml);
 }
 //孫カテゴリーのHTML

--- a/app/assets/stylesheets/modules/news.scss
+++ b/app/assets/stylesheets/modules/news.scss
@@ -201,8 +201,15 @@
 }
 
 .parent_category_box{
-  width: 95%;
+  width: 100%;
   height: 3vh;
   line-height: 1.2;
 } 
 
+.item_input__body__category{
+  &__children--select,&__grandchildren--select{
+  width: 100%;
+  height: 3vh;
+  line-height: 1.2;
+  }
+}

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -30,13 +30,8 @@ class ProductsController < ApplicationController
 
   def show
     @image_first = Image.where(product_id: @product).first.src.url
-
-    array_image = []
     @images = Image.where(product_id: @product).slice(1..-1)
-    @images.each do |image|
-      array_image << image
-    end
-    @kaminari_images = Kaminari.paginate_array(array_image).page(params[:page]).per(3)
+    @kaminari_images = Kaminari.paginate_array(@images).page(params[:page]).per(3)
       respond_to do |format|
         format.html
         format.js

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -30,7 +30,7 @@ class ProductsController < ApplicationController
 
   def show
     @image_first = Image.where(product_id: @product).first.src.url
-    @images = Image.where(product_id: @product)
+    @images = Image.where(product_id: @product).limit(4)
     @category = Category.find(@product.category_id)
     @user = User.find(@product.user_id)
     @address = Prefecture.find(@product.prefecture_id)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -30,6 +30,7 @@ class ProductsController < ApplicationController
 
   def show
     @image_first = Image.where(product_id: @product).first.src.url
+    @images = Image.where(product_id: @product)
     @category = Category.find(@product.category_id)
     @user = User.find(@product.user_id)
     @address = Prefecture.find(@product.prefecture_id)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -30,7 +30,17 @@ class ProductsController < ApplicationController
 
   def show
     @image_first = Image.where(product_id: @product).first.src.url
-    @images = Image.where(product_id: @product).limit(4)
+
+    array_image = []
+    @images = Image.where(product_id: @product).slice(1..-1)
+    @images.each do |image|
+      array_image << image
+    end
+    @kaminari_images = Kaminari.paginate_array(array_image).page(params[:page]).per(3)
+      respond_to do |format|
+        format.html
+        format.js
+      end
     @category = Category.find(@product.category_id)
     @user = User.find(@product.user_id)
     @address = Prefecture.find(@product.prefecture_id)

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -8,8 +8,9 @@ class Product < ApplicationRecord
   validates :infomation, length: { maximum: 300 }
   validates :price,
             numericality: {
+              less_than_or_equal_to: 9999999,
               greater_than_or_equal_to: 300,
-              message: "は300円以上にしてください"
+              message: "は300円以上、9999999円以下にしてください"
             }
   #以下のコメントアウトはのちの作業時に使用する。
   # belongs_to :seller, class_name: User, foreign_key: user_id

--- a/app/views/products/_showimage_page.html.haml
+++ b/app/views/products/_showimage_page.html.haml
@@ -1,0 +1,5 @@
+-# 上の方が見やすいので上に遷移コマンドを置いときます。
+= paginate @kaminari_images ,remote: true
+.mainbox__top__image__sub
+  - @kaminari_images.each do |images|
+    = image_tag images.src.url, alt: "kangaroo", class: "pics"

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -57,7 +57,6 @@
             -# = form.collection_select :category_id, Category.roots, :id, :category_name, {include_blank: "選択してください", selected: 1},  class: "parent_category_box", id: "parent_category"
             -# 親カテゴリーのみで登録されては困るため、「select :category_id」を「「select :category」とする。
             = form.select :category, options_for_select( @category_parent_array.map{|c| [c[:category_name], c[:id]]}),{include_blank: "選択してください"},  class: "parent_category_box", id: "parent_category"
-            = icon('fa', 'chevron-down')
             .pulldown.item_input__body__category__children#children_box
               -#親カテゴリー選択によって子カテゴリー表示
             .pulldown.item_input__body__category__grandchildren#grandchildren_box

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -30,10 +30,10 @@
         = @product.name
       .mainbox__top__image
         = image_tag @image_first, alt: "kangaroo", class: "kangaroo"
-        - unless @images.nil?
+        - unless @images.second.nil?
           .mainbox__top__image__sub
-            -# = link_to ("#"),{ class: "pics"} do
-            = image_tag @images.second.src.url, alt: "kangaroo", class: "pics"
+            - @images.slice(1..3).each do |images|
+              = image_tag images.src.url, alt: "kangaroo", class: "pics"
             -# = link_to ("#"),{ class: "pics"} do
             -#   = image_tag "icon-01.png", alt: "kangaroo1", class: "kangarooo"
             -# = link_to ("#"),{ class: "pics"} do

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -30,14 +30,12 @@
         = @product.name
       .mainbox__top__image
         = image_tag @image_first, alt: "kangaroo", class: "kangaroo"
-        - unless @images.second.nil?
-          .mainbox__top__image__sub
-            - @images.slice(1..3).each do |images|
-              = image_tag images.src.url, alt: "kangaroo", class: "pics"
-            -# = link_to ("#"),{ class: "pics"} do
-            -#   = image_tag "icon-01.png", alt: "kangaroo1", class: "kangarooo"
-            -# = link_to ("#"),{ class: "pics"} do
-            -#   = image_tag "icon-01.png", alt: "kangaroo2", class: "kangarooo"
+        - unless @images.nil?
+          #pagenate_image
+            = render "showimage_page"
+          -# .mainbox__top__image__sub
+          -#   - @images.each do |images|
+          -#     = image_tag images.src.url, alt: "kangaroo", class: "pics"
       .mainbox__top__price
         ¥
         = @product.price

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -30,13 +30,14 @@
         = @product.name
       .mainbox__top__image
         = image_tag @image_first, alt: "kangaroo", class: "kangaroo"
-        .mainbox__top__image__sub
-          = link_to ("#"),{ class: "pics"} do
-            = image_tag "icon-01.png", alt: "kangaroo", class: "kangarooo"
-          = link_to ("#"),{ class: "pics"} do
-            = image_tag "icon-01.png", alt: "kangaroo1", class: "kangarooo"
-          = link_to ("#"),{ class: "pics"} do
-            = image_tag "icon-01.png", alt: "kangaroo2", class: "kangarooo"
+        - unless @images.nil?
+          .mainbox__top__image__sub
+            -# = link_to ("#"),{ class: "pics"} do
+            = image_tag @images.second.src.url, alt: "kangaroo", class: "pics"
+            -# = link_to ("#"),{ class: "pics"} do
+            -#   = image_tag "icon-01.png", alt: "kangaroo1", class: "kangarooo"
+            -# = link_to ("#"),{ class: "pics"} do
+            -#   = image_tag "icon-01.png", alt: "kangaroo2", class: "kangarooo"
       .mainbox__top__price
         ¥
         = @product.price

--- a/app/views/products/show.js.haml
+++ b/app/views/products/show.js.haml
@@ -1,1 +1,2 @@
 $('#pagenate').html("#{escape_javascript(render 'show_page')}");
+$('#pagenate_image').html("#{escape_javascript(render 'showimage_page')}");

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -44,45 +44,52 @@ describe Product do
     it "is invalid without a price" do
       product = build(:product, price: nil)
       product.valid?
-      expect(product.errors.full_messages).to include("商品価格を入力してください", "商品価格は300円以上にしてください")
+      expect(product.errors.full_messages).to include("商品価格を入力してください", "商品価格は300円以上、9999999円以下にしてください")
       end
 
     # 7. priceが300円未満は登録できない
     it "is a price < 300" do
       product = build(:product, price: 299)
       product.valid?
-      expect(product.errors.full_messages).to include("商品価格は300円以上にしてください")
+      expect(product.errors.full_messages).to include("商品価格は300円以上、9999999円以下にしてください")
     end
 
-    # 8. prefecture_idが空では登録できないこと
+    # 8. priceが300円未満は登録できない
+    it "is a price > 9999999" do
+      product = build(:product, price: 99999999)
+      product.valid?
+      expect(product.errors.full_messages).to include("商品価格は300円以上、9999999円以下にしてください")
+    end
+    
+    # 9. prefecture_idが空では登録できないこと
     it "is invalid without a prefecture_id" do
       product = build(:product, prefecture_id: nil)
       product.valid?
       expect(product.errors.full_messages).to include("発送元地域を入力してください")
     end
 
-    # 9. conditionが空では登録できないこと
+    # 10. conditionが空では登録できないこと
     it "is invalid without a condition" do
       product = build(:product, condition_id: nil)
       product.valid?
       expect(product.errors.full_messages).to include("商品の状態を入力してください")
     end
 
-    # 10. delivery_charge_idが空では登録できないこと
+    # 11. delivery_charge_idが空では登録できないこと
     it "is invalid without a delivery_charge_id" do
       product = build(:product, delivery_charge_id: nil)
       product.valid?
       expect(product.errors.full_messages).to include("送料の負担を入力してください")
     end
 
-    # 11. shipping_day_idが空では登録できないこと
+    # 12. shipping_day_idが空では登録できないこと
     it "is invalid without a shipping_day_id" do
       product = build(:product, shipping_day_id: nil)
       product.valid?
       expect(product.errors.full_messages).to include("発送日数を入力してください")
     end
 
-    # 12. category_idが空では登録できないこと
+    # 13. category_idが空では登録できないこと
     it "is invalid without a category_id" do
       product = build(:product, category_id: nil)
       product.valid?


### PR DESCRIPTION
# What
商品詳細ページに於いて、投稿された画像を全て表示させる。
また、コードレビューに於いて指摘のあった出品ページにおけるバリデーションと表示を改善する。

# Why
ユーザーが出品した商品の情報を表示させるため。なお、画像以外のコードレビューは完了済み。
コードレビューで指摘されたバリデーションは価格の最大値を設けていなかったため、価格の最大値を設けた。それに伴いテストコードの作成も行った。
また、カテゴリー選択箇所に余計なアイコンがあり指摘されたため、削除し見栄えを整えた。