### PR TITLE
商品編集ページ　バリデーション

### DIFF
--- a/app/assets/stylesheets/modules/itemdetail.scss
+++ b/app/assets/stylesheets/modules/itemdetail.scss
@@ -86,13 +86,15 @@
     .extrainfo{
       display: flex;
       justify-content: space-between;
-      padding: 0 30px 50px 30px;
+      padding: 0 30px 30px 30px;
       .favorite{
         color: #3CCACE;
         border: 1px solid #ffb340;
         border-radius: 40px;
         padding: 8px 10px;
         font-size: 14px;
+        display: flex;
+        align-items: center;
         a{
           color: #3CCACE;
         }
@@ -102,6 +104,8 @@
         border-radius: 5px;
         padding: 8px 10px;
         font-size: 14px;
+        display: flex;
+        align-items: center;
         a{
           color: black;
         }

--- a/app/assets/stylesheets/modules/news.scss
+++ b/app/assets/stylesheets/modules/news.scss
@@ -7,16 +7,17 @@
   
   .Header {
     &__logo {
-      margin: 0 auto;
       text-align: center;
-      padding: 20px 0;
+      margin-top: 30px;
+      margin-bottom: 60px;
     }   
   }
   
   .Products {
     background-color: #ffffff;
-    margin: 0 50px;
-    padding: 20px;
+    width: 600px;
+    margin: 0 auto;
+    padding: 0 20px;
     &__form {
       padding: 20px 0;
       font-weight: bold;
@@ -183,12 +184,13 @@
     }
   } 
   .Submit {
-      margin-top: 10px;
+      margin-top: 20px;
       align-items: center;
       @include button;
   }
   .Return {
     text-align: center;
+    padding-bottom: 10px;
     a{
       color: black;
     }

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -66,8 +66,8 @@ class ProductsController < ApplicationController
       # 上2行を簡略化したコードが下の1行
       redirect_to product_path(@product), notice: "商品情報が更新されました"
     else
-      flash.now[:alert] = "商品情報の更新ができませんでした"
-      render :edit
+      flash[:alert] = @product.errors.full_messages.join(',')
+      redirect_to edit_product_path
       # redirect_toの時はflash,renderの時はflash.now
     end
   end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -2,7 +2,7 @@ class Prefecture < ActiveHash::Base
 
   self.data = [
 
-      {id: 0, name: '選択してください'},
+      
       {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
       {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},
       {id: 7, name: '福島県'}, {id: 8, name: '茨城県'}, {id: 9, name: '栃木県'},

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,6 +14,8 @@
 
   %body
     .notifications
-      - flash.each do |key, value|
-        = content_tag(:div, value, class: key)
+      - if flash[:alert]
+      - else
+        - flash.each do |key, value|
+          = content_tag(:div, value, class: key)
     = yield

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -18,6 +18,11 @@
 
     .Products__form
       = form_with model: @product, local:true do |form|
+        .Products__form__notification
+          - if flash[:alert]
+            - flash.each do |message_type, message|
+              - message2 = message.gsub(",","<br>")
+              = message2.html_safe
         .Products__form__name  
           =form.label :"商品名"
           %span 必須
@@ -36,12 +41,12 @@
               .pulldown#partent_box
                 -# 以下new.html.hamlとの元々の親子孫のコード比較のため、それぞれコメントアウトしておく
                 -# = form.select :category, options_for_select( @category_parent_array.map{|c| [c[:category_name], c[:id]]}),{include_blank: "選択してください"}, { class: "parent_category_box", id: "parent_category"}
-                = form.collection_select :category_id, Category.roots, :id, :category_name, {include_blank: "---", selected: @product.category.root.id}, { class: "parent_category_box", id: "parent_category"}
+                = form.collection_select :category_id, Category.roots, :id, :category_name, {include_blank: "---", selected: @product.category.root.id}, class: "parent_category_box", id: "parent_category", required: true
                 .pulldown.item_input__body__category__children#children_box
-                  = form.collection_select :category_id, @product.category.parent.siblings, :id, :category_name, {include_blank: "---", selected: @product.category.parent.id}, {class: "parent_category_box", id: "children_category"}
+                  = form.collection_select :category_id, @product.category.parent.siblings, :id, :category_name, {include_blank: "---", selected: @product.category.parent.id}, class: "parent_category_box", id: "children_category", required: true
                   -# = form.select :category_id, options_for_select(@category_children_array.map{|c|[c[:category_name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @product.category.parent.id), {}, {class: "parent_category_box", id: "children_category"}
                 .pulldown.item_input__body__category__grandchildren#grandchildren_box
-                  = form.collection_select :category_id, @product.category.siblings, :id, :category_name, {include_blank: "---", selected: @product.category.id}, {class: "parent_category_box", id: "grandchildren_category"}
+                  = form.collection_select :category_id, @product.category.siblings, :id, :category_name, {include_blank: "---", selected: @product.category.id}, class: "parent_category_box", id: "grandchildren_category", required: true
                   -# = form.select :category_id, options_for_select(@category_grandchildren_array.map{|c| [c[:category_name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @product.category.id), {}, {class: "parent_category_box", id: "grandchildren_category"}
 
         .Products__form__brand
@@ -52,22 +57,22 @@
         .Products__form__condition
           =form.label "商品の状態"
           %span 必須
-          =form.collection_select :condition_id, Condition.all, :id, :name, { class:"Products__form__conditionSelect"}
+          =form.collection_select :condition_id, Condition.all, :id, :name, { prompt: "選択してください" }, class:"Products__form__conditionSelect"
 
         .Products__form__deliveryCharge
           =form.label "送料の負担"
           %span 必須
-          =form.collection_select :delivery_charge_id, DeliveryCharge.all, :id, :name, {class:"Products__form__ deliveryChargeSelect"}
+        =form.collection_select :delivery_charge_id, DeliveryCharge.all, :id, :name, {prompt: "選択してください" }, class:"Products__form__ deliveryChargeSelect"
 
         .Products__form__deliveryFrom
           =form.label "発送元地域"
           %span 必須
-          =form.collection_select :prefecture_id, Prefecture.all, :id, :name, {class: "Products__form__deliveryFromSelect"}
+          =form.collection_select :prefecture_id, Prefecture.all, :id, :name, { prompt: "選択してください" }, class: "Products__form__deliveryFromSelect"
 
         .Products__form__shippingDay
           =form.label "発送日数"
           %span 必須
-          =form.collection_select :shipping_day_id ,ShippingDay.all, :id, :name, {class:"Products__form__shippingDaySelect"}
+          =form.collection_select :shipping_day_id ,ShippingDay.all, :id, :name, { prompt: "選択してください" }, class:"Products__form__shippingDaySelect"
 
         .Products__form__price
           価格(300~9,999,999)

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -71,9 +71,6 @@
             %td
               = @product.brand
           %tr
-            %th 商品のサイズ
-            %td 
-          %tr
             %th 商品の状態
             %td 
               - unless @product.buyer_id.present?
@@ -93,7 +90,7 @@
             %td
               = @shipping_day.name
       .extrainfo
-        %ul
+        %ul.box
           %li.favorite
             = icon('fas', 'heart', class: "likes")
             = link_to "お気に入り"


### PR DESCRIPTION
# What
・商品編集ページのバリデーション
　編集ページのため、商品名、商品説明、販売価格にバリデーションがかかっています。
　※写真機能については、別ブランチを切った後に実装を行います。
・その他、編集ページの画面サイズの調整、詳細ページのテーブル「サイズ」欄の削除と細かい調整もあります。

# Why
バリデーションがかかっていないと、商品名、商品説明、販売価格が空欄のまま更新が可能になってしまうため。