### PR TITLE
商品価格表示の修正

### DIFF
--- a/app/views/categories/_show_page.html.haml
+++ b/app/views/categories/_show_page.html.haml
@@ -9,7 +9,7 @@
         .category--prodboxs--lis--product--body--detail
           %ul.detaillist
             %li
-              = item.price
+              = item.price.to_s.reverse.scan(/.{1,3}/).join(',').reverse
               円
             %li
               = icon('fas', 'fa-star', class: "staricon")

--- a/app/views/items/_index_page.html.haml
+++ b/app/views/items/_index_page.html.haml
@@ -13,7 +13,7 @@
         .category--prodboxs--lis--product--body--detail
           %ul.detaillist
             %li
-              = item.price
+              = item.price.to_s.reverse.scan(/.{1,3}/).join(',').reverse
               円
             %li
               = icon('fas', 'fa-star', class: "staricon")

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -92,7 +92,7 @@
                 .category--prodboxs--lis--product--body--detail
                   %ul.detaillist
                     %li
-                      = item.price
+                      = item.price.to_s.reverse.scan(/.{1,3}/).join(',').reverse
                       円
                     %li
                       = icon('fas', 'fa-star', class: "staricon")
@@ -118,7 +118,7 @@
                 .category--prodboxs--lis--product--body--detail
                   %ul.detaillist
                     %li
-                      = item.price
+                      = item.price.to_s.reverse.scan(/.{1,3}/).join(',').reverse
                       円
                     %li
                       = icon('fas', 'fa-star', class: "staricon")

--- a/app/views/products/_show_page.html.haml
+++ b/app/views/products/_show_page.html.haml
@@ -12,12 +12,12 @@
         .category--prodboxs--lis--product--body--detail
           %ul.detaillist
             %li
-              = item.price
+              = item.price.to_s.reverse.scan(/.{1,3}/).join(',').reverse
               円
             %li
               = icon('fas', 'fa-star', class: "staricon")
               1
           %p (税込)
           -# カテゴリ確認のための一時的な表示です
-          = Category.find(item.category_id).category_name
+          -# = Category.find(item.category_id).category_name
 = paginate @items ,remote: true

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -46,7 +46,7 @@
 
       .mainbox__top__price
         ¥
-        = @product.price
+        = @product.price.to_s.reverse.scan(/.{1,3}/).join(',').reverse
         .mainbox__top__price__tax
           (税込)送料込み
       .product-description

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -13,7 +13,7 @@
           .purchase--main--fourinfo--threeinfo--productname
             = @product.name
           .purchase--main--fourinfo--threeinfo--productprice
-            = @product.price
+            = @product.price.to_s.reverse.scan(/.{1,3}/).join(',').reverse
             円(税込)
           .purchase--main--fourinfo--threeinfo--productdel
             = @delivery_charge.name
@@ -21,7 +21,7 @@
         %label.purchase--main--priceinfo--title 支払い金額
         %label.purchase--main--priceinfo--price
           ¥
-          = @product.price
+          = @product.price.to_s.reverse.scan(/.{1,3}/).join(',').reverse
 
       .purchase--main--priceinfo
         .purchase-container


### PR DESCRIPTION
# What
商品価格の表示を変更し、見やすくする。（例：5555円→5,555円）
# Why
大体１0万円以上の商品になると３桁ごとに”，”がないと見にくくなり、商品価格の判断が困難になるため。