### PR TITLE
パンくずの実装

### DIFF
--- a/app/views/categories/_breadcrumbtrail.html.haml
+++ b/app/views/categories/_breadcrumbtrail.html.haml
@@ -1,3 +1,4 @@
+-# 以下パンくずのコード
 %nav.root
   %ul.root--category
     %li.root--category--name

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -1,4 +1,5 @@
 = render "items/top"
+-# 以下”****”までパンくずのコード
 %nav.root
   %ul.root--category
     %li.root--category--name
@@ -33,6 +34,7 @@
       %li.root--category--name
         = link_to category_path(@category.id),{class:"root--category--name--link"} do
           = @category.category_name
+-# ”****”
 .main
   .showmain
     .showmain--right

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -1,4 +1,5 @@
 = render "items/top"
+-# 以下”****”までパンくずのコード
 %nav.root
   %ul.root--category
     %li.root--category--name
@@ -23,6 +24,7 @@
     %li.root--category--logo >
     %li.root--category--name
       = @product.name
+-# ”****”
 .main-show
   .mainbox
     .mainbox__top


### PR DESCRIPTION
# What
追加実装としてパンくずを実装し、ユーザーがWEBのどこにいるかを視覚化する。
ただし、カテゴリ機能、商品詳細ページを実装中に作成したため、確認のみ依頼する。

# Why
ユーザーがWEBのどこにいるかを視覚化しわかりやすくするため。
※機能そのものは他機能を実装中に別理由で実装したため、この段階では特に何もしていない。