### PR TITLE
配送先情報の修正

### DIFF
--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -8,25 +8,25 @@
           = f.label :氏名
           %span1.form-require 必須
           %br/
-        = f.text_field :ship_first_name, autofocus: true, class: 'input-default', placeholder: "例）鈴木"
+        = f.text_field :ship_family_name, autofocus: true, class: 'input-default', placeholder: "例）鈴木"
       .field
         .contents
           = f.label :名前
           %span1.form-require 必須
           %br/
-        = f.text_field :ship_family_name, autofocus: true, class: 'input-default', placeholder: "例）太朗"
+        = f.text_field :ship_first_name, autofocus: true, class: 'input-default', placeholder: "例）太朗"
       .field
         .contents
           = f.label :氏名（かな）
           %span1.form-require 必須
           %br/
-        = f.text_field :ship_first_name_kana, autofocus: true, class: 'input-default', placeholder: "例）すずき"
+        = f.text_field :ship_family_name_kana, autofocus: true, class: 'input-default', placeholder: "例）すずき"
       .field
         .contents
           = f.label :名前（かな）
           %span1.form-require 必須
           %br/
-        = f.text_field :ship_family_name_kana, autofocus: true, class: 'input-default', placeholder: "例）たろう"
+        = f.text_field :ship_first_name_kana, autofocus: true, class: 'input-default', placeholder: "例）たろう"
       .field
         .contents
           = f.label :郵便番号

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -33,7 +33,7 @@
                 .Products__form__images__box__previews__group__jsRemove 削除
               -# 新規作成時にはaccepts_nested_attributes_forメソッドを通じて子要素の画像の更新や削除を行う必要がないため、保存していない際にこの子要素の削除について決めるチェックボックスをview上に表示する必要がない
               - if @product.persisted?
-                = i.check_box :_destroy, data: { index: i.index}, class: "hidden-destroy", style: "display: block;"
+                = i.check_box :_destroy, data: { index: i.index}, class: "hidden-destroy", style: "display: none;"
             -# 編集画面のフォームでは新しく画像を追加する可能性もあるため、新規画像追加のためのボタンを表示させている
             -# fields_forの外にあるのは新規の入力欄。editでビルドされる入力欄は既存の画像枚数分だけなので、画像追加用のinputを生成している
             - if @product.persisted?


### PR DESCRIPTION
# What
ビューにおける配送先情報の氏名と名前の登録先カラムが逆になっており、購入画面で「姓 名」ではなく「名 姓」の表示になってしまった。そのため、「姓 名」の表示に修正した。

# Why
国際基準の指定がある訳ではないので、日本表記の「姓 名」の表示にするため。